### PR TITLE
PR for #5: plot aesthetics

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -21,6 +21,7 @@ def gamma_example():
     ex_object.pp_plot(outfile=False)
     ex_object.get_bias_corrected_tvd(num_sets = 2, detail = False)
     ex_object.density_plot(outfile = False)
+    ex_object.get_crossings(outfile = False)
     ex_object.get_tv_min()
     
     ### Vertical-distance-minimizing normal approximation to bootstrap replicates
@@ -45,6 +46,7 @@ def normal_example():
     ex_object.pp_plot(outfile=False)
     ex_object.get_bias_corrected_tvd(num_sets = 2, detail = False)
     ex_object.density_plot(outfile = False)
+    ex_object.get_crossings(outfile = False)
     
     ### Vertical-distance-minimizing normal approximation to bootstrap replicates
     ex_object.get_sk_min()

--- a/src/BootstrapReport/BootstrapReport.py
+++ b/src/BootstrapReport/BootstrapReport.py
@@ -102,7 +102,7 @@ class ObjectOfInterest(DiagnosticsMixin):
 
         return bias
     
-    def get_crossings(self, alpha = 0.05, outfile = None):
+    def get_crossings(self, alpha = 0.05, outfile = None, **kwargs):
         """ calculate minimum changes in direction consistent with difference in CDFs
         :param alpha: 1 - alpha = confidence level for confidence bands
         :param outfile: path to output figure displaying algorithm
@@ -163,7 +163,7 @@ class ObjectOfInterest(DiagnosticsMixin):
 
         if not outfile == None:
             helpers.plot_min_crossings(outfile, optimal_path, self.crossings, alpha, self.replicates, self.estimate,
-                                       self.se, upper_cb, lower_cb, left_upper_cb)
+                                       self.se, upper_cb, lower_cb, left_upper_cb, **kwargs)
 
     def pp_plot(self, confidence_band = True, alpha = 0.05, outfile=False, **kwargs):
         """ create the pp plot
@@ -172,7 +172,7 @@ class ObjectOfInterest(DiagnosticsMixin):
         :param alpha: the upper bound for the probability that an ecdf plot of the normal
             approximation falls outside the shaded region
         """
-        plt_set = {'fontsize': 18, 'legend_fontsize': 20, 'labelsize': 28, 'pointsize': 7, 'pointcolor': '#f9665e', 'bandcolor': '#a8d9ed'}
+        plt_set = {'fontsize': 18, 'legend_fontsize': 20, 'labelsize': 28, 'pointsize': 7, 'pointcolor': '#f9665e', 'bandcolor': '#a8d9ed', 'dpi': 100}
         for key, value in kwargs.items():
             plt_set[key] = value
         num_replicates = len(self.replicates)
@@ -211,17 +211,20 @@ class ObjectOfInterest(DiagnosticsMixin):
         plt.xlim(-0.05, 1.05)
 
         if outfile:
-            plt.savefig(outfile, transparent = True, dpi = 100)
+            plt.savefig(outfile, transparent = True, dpi = plt_set['dpi'])
         plt.clf()
         mpl.rcParams.update(mpl.rcParamsDefault)
             
             
-    def density_plot(self, bounds = None, bandwidth = None, outfile = False):
+    def density_plot(self, bounds = None, bandwidth = None, outfile = False, **kwargs):
         """ creates a smoothed density plot of replicates and shows the plot or outputs the result to outfile
         :param bounds: a tuple or list of the bounds of the density plot | Optional
         :param bandwidth: the bandwidth that the replicates are evaluated at when taking the kernel density estimate | Optional
         :param outfile: location of the file to be saved | Optional
         """
+        plt_set = {'fontsize': 18, 'legend_fontsize': 20, 'labelsize': 28, 'linecolor': '#f9665e', 'linewidth': 1, 'dpi': 100}
+        for key, value in kwargs.items():
+            plt_set[key] = value
         if not bandwidth:
             bandwidth = self.best_bandwidth_value
         if bounds != None:
@@ -234,19 +237,19 @@ class ObjectOfInterest(DiagnosticsMixin):
         xgrid = np.linspace(lbound, ubound, len(self.replicates) * 100)
         density = [pdf_from_kde(x) for x in xgrid]
 
-        plt.rcParams.update({'font.size': 18})
-        plt.rcParams.update({'legend.fontsize': 20})
-        plt.rcParams.update({'axes.labelsize': 28})
+        plt.rcParams.update({'font.size': plt_set['fontsize']})
+        plt.rcParams.update({'legend.fontsize': plt_set['legend_fontsize']})
+        plt.rcParams.update({'axes.labelsize': plt_set['labelsize']})
 
         plt.xlim(lbound, ubound)
         plt.xlabel('Value of object of interest')
         plt.ylabel('Density')
-        plt.plot(xgrid, density, linewidth = 1, color = '#f9665e')
+        plt.plot(xgrid, density, linewidth = plt_set['linewidth'], color = plt_set['linecolor'])
         plt.plot([self.replicates[0], self.replicates[-1]], [0.0001, 0.0001], '|k', markeredgewidth = 1, label = 'Range of bootstrap replicates')
         plt.legend(loc = 'best', fontsize = 'x-small', markerscale = 0.75)
         
         if outfile:
-            plt.savefig(outfile, transparent = True, dpi = 75)
+            plt.savefig(outfile, transparent = True, dpi = plt_set['dpi'])
         plt.clf()
         mpl.rcParams.update(mpl.rcParamsDefault)
 

--- a/src/BootstrapReport/helpers.py
+++ b/src/BootstrapReport/helpers.py
@@ -193,7 +193,7 @@ def select_bandwidth(rot_se, max_grid, min_grid, num_gridpoints,
     
     return implied_normal_pdf, best_bandwidth, best_bandwidth_index, avg_tvd_list, expansion_count
 
-def plot_min_crossings(outfile, optimal_path, crossings, alpha, replicates, estimate, std, upper_cb, lower_cb, left_upper_cb):
+def plot_min_crossings(outfile, optimal_path, crossings, alpha, replicates, estimate, std, upper_cb, lower_cb, left_upper_cb, **kwargs):
     """ Create the plot for `get_crossings` of ObjectOfInterest
     :param outfile: destination for the plot
     :param optimal_path: nx2 numpy.array. First column contains x values, and second column contains y values of optimal path.
@@ -207,12 +207,18 @@ def plot_min_crossings(outfile, optimal_path, crossings, alpha, replicates, esti
     :param left_upper_cb: function that returns the left-handed limit of the difference between the upper confidence bound 
         and the cdf of the implied normal
     """
-    
+    plt_set = {'fontsize': 18, 'legend_fontsize': 20, 'labelsize': 28, 'linecolor': '#f9665e', 'bandcolor': '#a8d9ed', 'linewidth': 2, 'dpi': 100}
+    for key, value in kwargs.items():
+        plt_set[key] = value
     mpl.rcParams['axes.spines.bottom'] = False
+    plt.rcParams.update({'font.size': plt_set['fontsize']})
+    plt.rcParams.update({'legend.fontsize': plt_set['legend_fontsize']})
+    plt.rcParams.update({'axes.labelsize': plt_set['labelsize']})
+    
     num_rep, x, y = len(replicates), optimal_path[-1, 0], optimal_path[-1, 1]
     plot_data = ('Num. crossings = %d' % crossings)
     props = dict(boxstyle = 'round, pad = 0.75, rounding_size = 0.3', facecolor = 'white', alpha = 0.7)
-    plt.plot(optimal_path[:, 0], optimal_path[:, 1], color = '#f9665e', label = 'Optimal path')
+    plt.plot(optimal_path[:, 0], optimal_path[:, 1], color = plt_set['linecolor'], label = 'Optimal path', linewidth = plt_set['linewidth'])
     
     zero_null_rej = stats.norm.ppf(np.sqrt(np.log(2/alpha)/(2 * num_rep)), loc = estimate, scale = std)
     if zero_null_rej < replicates[0]:
@@ -236,8 +242,8 @@ def plot_min_crossings(outfile, optimal_path, crossings, alpha, replicates, esti
     else:
         postline = np.array([[replicates[-1], optimal_path[-1, 1]], [end + 0.5 * std, 0], [end + std, 0]])
     
-    plt.plot(preline[:, 0], preline[:, 1], color = '#f9665e')
-    plt.plot(postline[:, 0], postline[:, 1], color = '#f9665e')
+    plt.plot(preline[:, 0], preline[:, 1], color = plt_set['linecolor'], linewidth = plt_set['linewidth'])
+    plt.plot(postline[:, 0], postline[:, 1], color = plt_set['linecolor'], linewidth = plt_set['linewidth'])
     x_axis = np.concatenate([np.linspace(replicates[r], replicates[r + 1], 10) for r in range(num_rep - 1)], axis = None)
     x_axis = np.append(np.linspace(preline[0, 0], replicates[0], 15), x_axis)
     x_axis = np.append(x_axis, np.linspace(replicates[-1], postline[-1, 0], 15))
@@ -250,10 +256,10 @@ def plot_min_crossings(outfile, optimal_path, crossings, alpha, replicates, esti
     plt.hlines(y = botbound, xmin = lbound, xmax  = replicates[0], color = 'k', lw = 2, linestyle = (1.5, (1.5, 1)))
     plt.hlines(y = botbound, xmin = replicates[0], xmax  = replicates[-1], color = 'k', lw = 2)
     plt.hlines(y = botbound, xmin = replicates[-1], xmax = rbound, color = 'k', lw = 2, linestyle = (1.5, (1.5, 1)))
-    plt.fill_between(x_axis, lower_band, upper_band, color = '#a8d9ed', label = 'Confidence band', alpha = 0.25)
+    plt.fill_between(x_axis, lower_band, upper_band, color = plt_set['bandcolor'], label = 'Confidence band', alpha = 0.25)
     plt.legend(edgecolor = 'k', loc = 'upper left')
     plt.text(rbound - 0.04 * (rbound - lbound), botbound + 0.07 * (topbound - botbound), plot_data, 
-                fontsize = 13, verticalalignment = 'bottom', horizontalalignment='right', bbox = props)
-    plt.savefig(outfile, transparent = True, dpi = 100)
+                fontsize = plt_set['legend_fontsize'], verticalalignment = 'bottom', horizontalalignment='right', bbox = props)
+    plt.savefig(outfile, transparent = True, dpi = plt_set['dpi'])
     plt.clf()
     mpl.rcParams.update(mpl.rcParamsDefault)


### PR DESCRIPTION
In this issue we . . .

- Inside of `src\BootstrapReport\BootstrapReport.py`, edited the methods `get_crossings`, `pp_plot`, and `density_plot` to take in `kwargs` for plot aesthetics.
    - The way `kwargs` work is you can add extra variables when calling the function:
    e.g. instead of `my_object.pp_plot(alpha = 0.05, outfile = False)` you can write `my_object.pp_plot(alpha = 0.05, outfile = False, linewidth = 2, color = 'r' . . .)` to specify any plot aesthetics.
- Updated the `plot_min_crossings` in `helpers.py` to facilitate the changes in `get_crossings`
- Added `get_crossings` calls in `examples.py`

Adding @jmshapir