### PR TITLE
Pull Request for #16: Make heatmaps compatible with SK

### DIFF
--- a/src/BootstrapReport/_diagnostics.py
+++ b/src/BootstrapReport/_diagnostics.py
@@ -7,7 +7,7 @@ from scipy.stats import norm
 
 class DiagnosticsMixin:
     
-    def _heat_map(self, distance = "TV", density = 50, bounds = [], vrange = [0,1], outfile = False):
+    def _heat_map(self, distance = "SK", density = 50, bounds = [], vrange = [0,1], outfile = False):
         """ create a heat map showing total variation distance as mean and standard deviation are varied
         :param distance: string containing distance type, either 'TV' or 'SK'
         :param density: the density of the points in the heat map

--- a/src/BootstrapReport/_diagnostics.py
+++ b/src/BootstrapReport/_diagnostics.py
@@ -40,7 +40,7 @@ class DiagnosticsMixin:
         ax.invert_yaxis()
         ax.set_xlabel('σ')
         ax.set_ylabel('µ')
-        plt.title(f'{distance}D with varied µ and σ')
+        plt.title(f'{distance} with varied µ and σ')
     
         if outfile:
             plt.savefig(outfile, dpi=600)


### PR DESCRIPTION
In this issue, I edited the heatmap function in `_diagnostics.py` to allow users to make heatmaps using the SK distance as well as the TV distance. 

I also added a bounds and vrange argument so that users can zoom into the plot with more control and control the color scaling of the heatmap. These are very easy to remove if necessary.